### PR TITLE
Add simple Discord RSS bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
-# codex
+# Discord RSS Bot
+
+This repository contains a simple Discord bot that posts updates from an RSS feed into a channel.
+
+## Requirements
+
+- Python 3.8+
+- Dependencies listed in `requirements.txt`
+
+## Setup
+
+1. Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+2. Create a Discord bot and invite it to your server. Obtain the bot token and the channel ID where you want the RSS updates posted.
+
+3. Set the following environment variables:
+
+- `DISCORD_TOKEN` – your bot token
+- `CHANNEL_ID` – the ID of the channel to post in
+- `RSS_FEED_URL` – the RSS feed URL to monitor
+
+4. Run the bot:
+
+```bash
+python rss_bot.py
+```
+
+The bot will check the RSS feed every five minutes and send new entries to the specified channel.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+discord.py
+feedparser

--- a/rss_bot.py
+++ b/rss_bot.py
@@ -1,0 +1,43 @@
+import os
+import asyncio
+import feedparser
+import discord
+
+TOKEN = os.getenv('DISCORD_TOKEN')
+CHANNEL_ID = int(os.getenv('CHANNEL_ID', '0'))
+RSS_FEED_URL = os.getenv('RSS_FEED_URL')
+
+if not all([TOKEN, CHANNEL_ID, RSS_FEED_URL]):
+    raise RuntimeError('DISCORD_TOKEN, CHANNEL_ID and RSS_FEED_URL must be set as environment variables')
+
+intents = discord.Intents.default()
+client = discord.Client(intents=intents)
+
+last_published = None
+
+async def poll_feed():
+    global last_published
+    await client.wait_until_ready()
+    channel = client.get_channel(CHANNEL_ID)
+    if channel is None:
+        print(f"Could not find channel with ID {CHANNEL_ID}")
+        return
+    while not client.is_closed():
+        feed = feedparser.parse(RSS_FEED_URL)
+        for entry in reversed(feed.entries):
+            published = entry.get('published_parsed')
+            if not published:
+                continue
+            if last_published is None or published > last_published:
+                link = entry.get('link')
+                title = entry.get('title')
+                await channel.send(f"{title}\n{link}")
+                last_published = published
+        await asyncio.sleep(300)  # check every 5 minutes
+
+@client.event
+def on_ready():
+    print(f'Logged in as {client.user}')
+
+client.loop.create_task(poll_feed())
+client.run(TOKEN)


### PR DESCRIPTION
## Summary
- implement `rss_bot.py` for a basic RSS-to-Discord bridge
- document setup and usage instructions
- list dependencies in `requirements.txt`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683fcdc0826883269fe0f5be13311985